### PR TITLE
Fixed parsing error on login error

### DIFF
--- a/booking-mvc/src/main/webapp/WEB-INF/login.html
+++ b/booking-mvc/src/main/webapp/WEB-INF/login.html
@@ -65,7 +65,9 @@
 
     <div class="error" th:if="${param.login_error}">
         Your login attempt was not successful, try again.<br /><br />
-        Reason: <span th:text="${session[__${lastExceptionKey}__].message}">Invalid password</span> 
+        <span th:if="${session} and ${session[__${lastExceptionKey}__]}">
+            Reason: <span th:text="${session[__${lastExceptionKey}__].message}">Invalid password</span>
+        </span> 
     </div>
     
     <form name="f" action="#" th:action="@{/loginProcess}" method="post">
@@ -78,7 +80,7 @@
                 <label for="j_username">User:</label>
                 <br />
                 <input type="text" name="j_username" id="j_username"
-                       th:value="${param.login_error} ? ${session[__${lastUsernameKey}__]} : ''" />
+                       th:value="(${param.login_error} and ${session}) ? ${session[__${lastUsernameKey}__]} : ''" />
             </p>
             
             <script type="text/javascript">


### PR DESCRIPTION
This pull request fixes the possibility of receiving an expression parsing error when:
- Bad login credentials have been input, and we're being shown the login error page.
- Session expires
- We hit F5

The error is due to the `session` variables map (containing the _session attributes_) not being checked for nullity when an `HttpSession` has not been initialized (or has expired).
