### PR TITLE
Fix loading of WebFlowConfig to dispatcher servlet application context.

### DIFF
--- a/booking-mvc/src/main/java/org/springframework/webflow/samples/booking/config/DispatcherServletInitializer.java
+++ b/booking-mvc/src/main/java/org/springframework/webflow/samples/booking/config/DispatcherServletInitializer.java
@@ -11,15 +11,16 @@ public class DispatcherServletInitializer  extends AbstractAnnotationConfigDispa
 	protected Class<?>[] getRootConfigClasses() {
 		return new Class<?>[] {
 			SecurityConfig.class,
-			DataAccessConfig.class,
-			WebMvcConfig.class,
-			WebFlowConfig.class
+			DataAccessConfig.class
 		};
 	}
 
 	@Override
 	protected Class<?>[] getServletConfigClasses() {
-		return null;
+		return new Class<?>[] { 
+			WebMvcConfig.class,
+			WebFlowConfig.class
+		};
 	}
 
 	@Override

--- a/booking-mvc/src/main/java/org/springframework/webflow/samples/booking/config/WebMvcConfig.java
+++ b/booking-mvc/src/main/java/org/springframework/webflow/samples/booking/config/WebMvcConfig.java
@@ -5,6 +5,7 @@ import java.util.Set;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.web.servlet.config.annotation.DefaultServletHandlerConfigurer;
 import org.springframework.web.servlet.config.annotation.EnableWebMvc;
@@ -26,6 +27,7 @@ import org.thymeleaf.templateresolver.ServletContextTemplateResolver;
 
 @EnableWebMvc
 @Configuration
+@ComponentScan(basePackages = {"org.springframework.webflow.samples.booking"})
 public class WebMvcConfig extends WebMvcConfigurerAdapter {
 
 	@Autowired


### PR DESCRIPTION
After switching spring context configuration from xml to java classes in 20 Feb 2014, booking-mvc sample cannot be loaded. This has been fix after 
1) Moving WebMvcConfig.class, WebFlowConfig.class to getServletConfigClasses.
2) Adding annotation for component scan.

The fix have been tested in TC server v2.9.
