### PR TITLE
Maven should use 'tomcat7:run'

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Samples without a Portlet dependency can be run with the Tomcat Maven plugin. Fo
 
 ````
 cd booking-mvc
-mvn tomcat:run
+mvn tomcat7:run
 ````
 
 Eclipse


### PR DESCRIPTION
Current README says booking-mvc should be run with:

```
mvn tomcat:run
```

This fails with error:

> [INFO] ------------------------------------------------------------------------
> [INFO] BUILD FAILURE
> [INFO] ------------------------------------------------------------------------
> [INFO] Total time: 3:56.053s
> [INFO] Finished at: Tue Apr 08 13:01:05 CDT 2014
> [INFO] Final Memory: 17M/118M
> [INFO] ------------------------------------------------------------------------
> [ERROR] Failed to execute goal org.apache.tomcat:tomcat-maven-plugin:1.0:run (default-cli) on project booking-mvc: The parameters 'servers' for goal org.apache.tomcat:tomcat-maven-plugin:1.0:run are missing or invalid -> [Help 1]

This can be fixed by doing instead:

```
mvn tomcat7:run
```
