### PR TITLE
Fix mass-assignment issue

### DIFF
--- a/booking-mvc/src/main/webapp/WEB-INF/hotels/booking/booking-flow.xml
+++ b/booking-mvc/src/main/webapp/WEB-INF/hotels/booking/booking-flow.xml
@@ -32,7 +32,7 @@
 		<transition on="cancel" to="cancel" bind="false" />
 	</view-state>
 	
-	<view-state id="reviewBooking" model="booking">
+	<view-state id="reviewBooking">
 		<on-render>
 			<render fragments="body" />
 		</on-render>


### PR DESCRIPTION
The booking model should only be bound in the "enterBookingDetails" state where the binder is properly configured to prevent a mass-assignment vulnerability which allows an attacker to access nested properties such as Hotel or User properties.
Note that there is no need to bind the model in the "reviewBooking" state and that by allowing it without configuring the binder, an attacker may change any nested properties in this step of the flow, overcoming the binder protection in the previous step.