### PR TITLE
Add maven build:plugin to pom file so it can run now

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -49,6 +49,16 @@
 			</dependency>
 		</dependencies>
 	</dependencyManagement>
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>org.eclipse.jetty</groupId>
+				<artifactId>jetty-maven-plugin</artifactId>
+				<version>9.4.8.v20171121</version>
+			</plugin>
+		</plugins>
+	</build>
+
 
 	<!--
 	<repositories>


### PR DESCRIPTION
I couldn't run this project from the commandline in spite of following the guidelines of running:
`mvn jetty:run`

I added the plugin for jetty and it ran fine

I am using Maven 3.6 on Ubuntu 18.04.4